### PR TITLE
ftol for mincresample using input volume step sizes

### DIFF
--- a/volume_io/Include/volume_io/vol_io_prototypes.h
+++ b/volume_io/Include/volume_io/vol_io_prototypes.h
@@ -81,6 +81,26 @@ VIOAPI  VIO_Transform  *get_linear_transform_ptr(
 VIOAPI  VIO_Transform  *get_inverse_linear_transform_ptr(
     VIO_General_transform   *transform );
 
+VIOAPI  VIO_Status  general_transform_point_with_input_steps(
+    VIO_General_transform   *transform,
+    VIO_Real                x,
+    VIO_Real                y,
+    VIO_Real                z,
+    VIO_Real                *input_volume_steps,
+    VIO_Real                *x_transformed,
+    VIO_Real                *y_transformed,
+    VIO_Real                *z_transformed );
+
+VIOAPI  VIO_Status  general_inverse_transform_point_with_input_steps(
+    VIO_General_transform   *transform,
+    VIO_Real                x,
+    VIO_Real                y,
+    VIO_Real                z,
+    VIO_Real                *input_volume_steps,
+    VIO_Real                *x_transformed,
+    VIO_Real                *y_transformed,
+    VIO_Real                *z_transformed );
+
 VIOAPI  VIO_Status  general_transform_point(
     VIO_General_transform   *transform,
     VIO_Real                x,
@@ -2081,6 +2101,16 @@ VIOAPI  VIO_Status  grid_transform_point(
     VIO_Real                *y_transformed,
     VIO_Real                *z_transformed );
 
+VIOAPI  VIO_Status  grid_inverse_transform_point_with_input_steps(
+    VIO_General_transform   *transform,
+    VIO_Real                x,
+    VIO_Real                y,
+    VIO_Real                z,
+    VIO_Real                *input_volume_steps,
+    VIO_Real                *x_transformed,
+    VIO_Real                *y_transformed,
+    VIO_Real                *z_transformed );
+    
 VIOAPI  VIO_Status  grid_inverse_transform_point(
     VIO_General_transform   *transform,
     VIO_Real                x,


### PR DESCRIPTION
When using mincresample, the tolerance/precision (ftol) for calculating the position of resampled voxels is based on the step sizes of the deformation grid. These step sizes can differ from the input volume being resampled. This commit (together with a commit in the minc-tools repository) base the ftol variable on the step sizes of the input volume rather than the deformation grid.
