### PR TITLE
BUG: Return proper enumerated value from nc_type_to_minc2_type

### DIFF
--- a/libsrc2/minc2_structs.h
+++ b/libsrc2/minc2_structs.h
@@ -42,6 +42,7 @@ typedef void *milisthandle_t;
  * stored</b> by MINC 2.0. 
  */
 typedef enum {
+  MI_TYPE_ORIGINAL = 0,     /**< MI_ORIGINAL_TYPE */
   MI_TYPE_BYTE = 1,         /**< 8-bit signed integer */
   MI_TYPE_SHORT = 3,        /**< 16-bit signed integer */
   MI_TYPE_INT = 4,          /**< 32-bit signed integer */


### PR DESCRIPTION
The function "nc_type_to_minc2_type" is expected to return a value of type
"mitype_t", which is an enumerated type. "mitype_t" does not specific a
value equivalent to 0, so returning "MI_ORIGINAL_TYPE" (which is 0)
produces a warning.

The "nc_type" of "MI_ORIGINAL_TYPE" is a stand-in for "NC_NAT"
(i.e. 'Not A Type" [1]). This semantically best corresponds to the
"mitype_t" of "MI_TYPE_UNKNOWN".

[1] http://www.unidata.ucar.edu/mailing_lists/archives/netcdfgroup/2000/msg00059.html
