### PR TITLE
COMP: Add enumerated value for MI_ORIGINAL_TYPE to mitype_t

### DIFF
--- a/libsrc2/minc2_structs.h
+++ b/libsrc2/minc2_structs.h
@@ -42,6 +42,7 @@ typedef void *milisthandle_t;
  * stored</b> by MINC 2.0. 
  */
 typedef enum {
+  MI_TYPE_ORIGINAL = 0,     /**< MI_ORIGINAL_TYPE */
   MI_TYPE_BYTE = 1,         /**< 8-bit signed integer */
   MI_TYPE_SHORT = 3,        /**< 16-bit signed integer */
   MI_TYPE_INT = 4,          /**< 32-bit signed integer */


### PR DESCRIPTION
The function "nc_type_to_minc2_type" returns a value of type "mitype_t".
As this function can return the value "MI_ORIGINAL_TYPE" (which is 0)
and "mitype_t" had no enumerated value of 0, a warning was being produced.

This commit adds an enumerated value of 0 to "mitype_t", allowing variables
of this type to legally hold the value "MI_ORIGINAL_TYPE".
