### PR TITLE
Fix crash when input file cannot be expanded

### DIFF
--- a/libsrc/voxel_loop.c
+++ b/libsrc/voxel_loop.c
@@ -2354,6 +2354,10 @@ PRIVATE int get_input_mincid(Loopfile_Info *loopfile_info,
       filename = miexpand_file(loopfile_info->input_files[file_num], NULL,
                                loopfile_info->headers_only,
                                &created_tempfile);
+      if (!filename) {
+         fprintf(stderr, "Could not expand file \"%s\"!\n", loopfile_info->input_files[file_num]);
+         exit(EXIT_FAILURE);
+      }
       loopfile_info->input_mincid[index] = miopen(filename, NC_NOWRITE);
       if (created_tempfile) {
          (void) remove(filename);


### PR DESCRIPTION
This fixes a segmentation fault that occurs when an input file indicates compression (e.g. by having an extension ".bz2", ".gz", etc.), but doesn't really contain data in the corresponding compression format. In this case, exit with an error message instead of just crashing.

The issue was originally discovered by the Mayhem program analysis software in a systematic check of the whole Debian repository. The circumstances of the crash have been reported to the Debian bug tracking system as bug 716511: http://bugs.debian.org/716511
