### PR TITLE
Initialize variables for clang warnings.

### DIFF
--- a/volume_io/Volumes/input_mnc2.c
+++ b/volume_io/Volumes/input_mnc2.c
@@ -79,7 +79,7 @@ static  Minc_file  initialize_minc_input_from_minc2_id(
     int                 d, which_valid_axis, axis;
     int                 spatial_axis_indices[MAX_VAR_DIMS];
     minc_input_options  default_options;
-    VIO_BOOL            no_volume_data_type;
+    VIO_BOOL            no_volume_data_type = TRUE;
     double              *irr_starts[MAX_VAR_DIMS];
     double              *irr_widths[MAX_VAR_DIMS];
 
@@ -645,6 +645,7 @@ static  VIO_Status   input_minc2_hyperslab(
     VIO_Colour           colour;
     VIO_multidim_array   buffer_array, rgb_array;
 
+    n_tmp_dims = file->n_file_dimensions;
     n_file_dims = file->n_file_dimensions;
     direct_to_array = TRUE;
     expected_ind = n_array_dims-1;
@@ -1090,7 +1091,7 @@ static  VIO_BOOL  match_dimension_names(
 {
     int       i, j, iteration, n_matches, dummy;
     int       to_file_index[VIO_MAX_DIMENSIONS];
-    VIO_BOOL  match;
+    VIO_BOOL  match = FALSE;
     VIO_BOOL  volume_dim_found[VIO_MAX_DIMENSIONS];
 
     n_matches = 0;

--- a/volume_io/Volumes/volumes.c
+++ b/volume_io/Volumes/volumes.c
@@ -2308,7 +2308,8 @@ VIOAPI  void  set_volume_voxel_range(
     VIO_Real     voxel_min,
     VIO_Real     voxel_max )
 {
-    VIO_Real  real_min, real_max;
+    VIO_Real  real_min = 0.0;
+    VIO_Real  real_max = 0.0;
 
     if( voxel_min >= voxel_max ) /*VF: trying to fix the situation when whole volume have the same value all around*/
     {


### PR DESCRIPTION
This is an attempt to address:

>In function 'set_volume_type2':
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/volumes.c:2311:
>note: 'real_max' was declared here
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/volumes.c:2311:
>note: 'real_min' was declared here
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/volumes.c:
>In function 'create_volume':
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/volumes.c:2311:
>note: 'real_max' was declared here
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/volumes.c:2311:
>note: 'real_min' was declared here
>
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/input_mnc2.c:
>In function 'input_more_minc2_file':
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/input_mnc2.c:637:
>note: 'n_tmp_dims' was declared here
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/input_mnc2.c:
>In function 'initialize_minc2_input':
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/input_mnc2.c:1093:
>note: 'match' was declared here
>/Users/builder/external/ITK/Modules/ThirdParty/MINC/src/libminc/
>volume_io/Volumes/input_mnc2.c:82:
>note: 'no_volume_data_type' was declared here

I have not reproduced locally because I do not have the source system.  These show up on the ITK dashboard.