### PR TITLE
Missing snprintf definition in time_stamp.c for Visual Studio

### DIFF
--- a/libcommon/time_stamp.c
+++ b/libcommon/time_stamp.c
@@ -62,6 +62,12 @@
 #include "config.h"
 #endif /*HAVE_CONFIG_H*/
 
+#ifdef _MSC_VER
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
+#endif
+
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif


### PR DESCRIPTION
time_stamp.c uses the function `snprintf()`. In Visual Studio, this
function is defined as `_snprintf()`. This can lead to linking errors.
`snprintf()` is defined in `minc_private.h`, but this is not enough to
avoid the linking errors. `minc_private.h` cannot be included in time_stamp.c
easily and creates more compilation errors. To avoid these problems, we define
`snprintf()` only if it is not already defined.