### PR TITLE
DONOTMERGE: Limit HDF5 file versioning to 1.8.x

### DIFF
--- a/libsrc/hdf_convenience.c
+++ b/libsrc/hdf_convenience.c
@@ -13,9 +13,9 @@
 #define MI2_LENGTH "length"
 #define MI2_CLASS "class"
 
-/* So we build with 1.8.4 */  
-#ifndef H5F_LIBVER_18
-#define H5F_LIBVER_18 H5F_LIBVER_LATEST
+/* Make 1.8.x compatible files if building with 1.10.x */  
+#ifndef H5F_LIBVER_V18
+#define H5F_LIBVER_V18 H5F_LIBVER_LATEST
 #endif
 
 /************************************************************************
@@ -2340,8 +2340,8 @@ hdf_create(const char *path, int cmode, struct mi2opts *opts_ptr)
       cmode = H5F_ACC_TRUNC;
     }
 
-    /*VF use all the features of new HDF5 1.8*/
-    H5Pset_libver_bounds (fpid, H5F_LIBVER_18, H5F_LIBVER_18);
+    /* Limit file compatability to 1.8.x */
+    H5Pset_libver_bounds (fpid, H5F_LIBVER_V18, H5F_LIBVER_V18);
 
     H5E_BEGIN_TRY {
         file_id = H5Fcreate(path, cmode, H5P_DEFAULT, fpid);

--- a/libsrc2/volume.c
+++ b/libsrc2/volume.c
@@ -32,9 +32,9 @@
 #include "minc2.h"
 #include "minc2_private.h"
 
-/* So we build with 1.8.4 */  
-#ifndef H5F_LIBVER_18
-#define H5F_LIBVER_18 H5F_LIBVER_LATEST
+/* Build with 1.8.x support if using 1.10.x */ 
+#ifndef H5F_LIBVER_V18
+#define H5F_LIBVER_V18 H5F_LIBVER_LATEST
 #endif
 
 /*Used to optimize chunking size for faster MINC1 API access*/
@@ -218,8 +218,8 @@ static hid_t _hdf_create(const char *path, int cmode)
   
   fpid = H5Pcreate (H5P_FILE_ACCESS);
 
-  /*VF use all the features of new HDF5 1.8*/
-  H5Pset_libver_bounds (fpid, H5F_LIBVER_18, H5F_LIBVER_18);
+  /* Limit filetype to 1.8.x */
+  H5Pset_libver_bounds (fpid, H5F_LIBVER_V18, H5F_LIBVER_V18);
   
   H5Pset_cache(fpid, 0, 2503, miget_cfg_present(MICFG_MINC_FILE_CACHE)?miget_cfg_int(MICFG_MINC_FILE_CACHE)*100000:_MI1_MAX_VAR_BUFFER_SIZE*100, 1.0);
   


### PR DESCRIPTION
ITKv5 recently pulled in HDF5 1.10.x. When they did, the MINC files they started generating were no longer readable with minc-toolkit because of HDF5 on-disk versioning change.

This change adapts the existing HDF5 versioning to recognize the new defs from 1.10.x and use them if defined, limiting the on-disk format to the 1.8.x series.

Implemented according to "What does this change mean to an HDF5 application?" at:
https://www.hdfgroup.org/2018/04/why-should-i-care-about-the-hdf5-1-10-2-release/