### PR TITLE
HDF5 1.10.x: Switch to checking defines instead of an enum

### DIFF
--- a/libsrc/hdf_convenience.c
+++ b/libsrc/hdf_convenience.c
@@ -14,7 +14,7 @@
 #define MI2_CLASS "class"
 
 /* Make 1.8.x compatible files if building with 1.10.x */  
-#ifndef H5F_LIBVER_V18
+#if (H5_VERS_MAJOR==1)&&(H5_VERS_MINOR<10)
 #define H5F_LIBVER_V18 H5F_LIBVER_LATEST
 #endif
 

--- a/libsrc2/volume.c
+++ b/libsrc2/volume.c
@@ -33,7 +33,7 @@
 #include "minc2_private.h"
 
 /* Build with 1.8.x support if using 1.10.x */ 
-#ifndef H5F_LIBVER_V18
+#if (H5_VERS_MAJOR==1)&&(H5_VERS_MINOR<10)
 #define H5F_LIBVER_V18 H5F_LIBVER_LATEST
 #endif
 


### PR DESCRIPTION
It turns out that HDF5 1.10 uses an typedef enum to define H5F_LIBVER_V18 so this code wasn't properly working.

I went back through the history of HDF5 releases and H5_VERS_MAJOR and H5_VERS_MINOR have been defines since long before 1.8 so this is a forward and backward compatible solution.