### PR TITLE
Created cmake.yml to test with github actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,49 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "master" ]
+  # pull_request:
+  #   branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        WITH_MINC1: ["OFF", "ON"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y libhdf5-dev libnetcdf-dev
+
+    - name: Configure CMake with Minc 1 ${{matrix.WITH_MINC1}}
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: |
+        minc_build_vars="-DLIBMINC_MINC1_SUPPORT:BOOL=${{matrix.with_minc1}} -DBUILD_TESTING:BOOL=ON"
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} $minc_build_vars
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      # Build your program with the given configuration
+      run: make
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: make test
+      


### PR DESCRIPTION
Based on Github's defaults for CMake-based projects, and the old .travis.yml file.

The run on master was successful - https://github.com/shai-ikko/libminc/actions/runs/2713055399. the "ON" and "OFF" jobs refer to MINC1 support -- you may see that in the "OFF" job, netCDF was not included in the configuration.

Note that I've set it up as requested, to run only on pushes to `master`, but Github's default is to also run it on PRs against `master`; I left that commented out in the config. This is not a "run your code on my github account" invitation, because project settings can limit who can run workflows; the default is to require approval for external collaborators the first time they make a PR, but you can also set it to always require approval for outside collaborators. 