### PR TITLE
Fixed undefined behaviour from doing arithmetic on a null pointer

### DIFF
--- a/libsrc2/volume.c
+++ b/libsrc2/volume.c
@@ -1447,7 +1447,9 @@ int miopen_volume(const char *filename, int mode, mihandle_t *volume)
     }
     /* Get dimension variable attributes for each dimension */
     _miget_file_dimension(handle, p1, &handle->dim_handles[i]);
-    p1 = p2 + 1;
+    if (p2 != NULL) {
+      p1 = p2 + 1;
+    }
   }
 
   if( miset_volume_world_indices(handle) < 0 ) {


### PR DESCRIPTION
On the last iteration of the loop, p2 is NULL.  It is thus invalid to compute p1 = p2 + 1.  Conditionlized the computation to p2 being non-NULL.  It's not very consequential, since p1 is not used again after the loop is done.