### PR TITLE
Fix building with GCC15 as C23

### DIFF
--- a/libcommon/ParseArgv.c
+++ b/libcommon/ParseArgv.c
@@ -111,6 +111,16 @@ ParseLong(const char *argPtr, char **endPtr)
  *	Process an argv array according to a table of expected
  *	command-line options.  See the manual page for more details.
  *
+ * argcPtr: Number of arguments in argv.  Modified to hold # args left in argv
+ *          at end.
+ *
+ * argv: Array of arguments.  Modified to hold those that couldn't be processed
+ *       here.
+ *
+ * argTable: Array of option descriptions
+ *
+ * flags: Or'ed combination of various flag bits, such as ARGV_NO_DEFAULTS.
+ *
  * Results:
  *	The return value is a Boolean value with non-zero indicating an 
  *      error.  
@@ -126,14 +136,7 @@ ParseLong(const char *argPtr, char **endPtr)
  */
 
 int
-ParseArgv(argcPtr, argv, argTable, flags)
-    int *argcPtr;		/* Number of arguments in argv.  Modified
-				 * to hold # args left in argv at end. */
-    char **argv;		/* Array of arguments.  Modified to hold
-				 * those that couldn't be processed here. */
-    ArgvInfo *argTable;	/* Array of option descriptions */
-    int flags;			/* Or'ed combination of various flag bits,
-				 * such as ARGV_NO_DEFAULTS. */
+ParseArgv(int *argcPtr, char **argv, ArgvInfo *argTable, int flags)
 {
    ArgvInfo *infoPtr;
 				/* Pointer to the current entry in the

--- a/libcommon/ParseArgv.c
+++ b/libcommon/ParseArgv.c
@@ -318,7 +318,8 @@ ParseArgv(int *argcPtr, char **argv, ArgvInfo *argTable, int flags)
          }
          break;
       case ARGV_FUNC: {
-         int (*handlerProc)() =  (int (*)())(uintptr_t)infoPtr->src;
+         typedef int (*handlerProcType)(void*, const char*, char*);
+         handlerProcType handlerProc = (handlerProcType)(uintptr_t)infoPtr->src;
 		
          if ((*handlerProc)(infoPtr->dst, infoPtr->key,
                             argv[srcIndex])) {
@@ -328,7 +329,8 @@ ParseArgv(int *argcPtr, char **argv, ArgvInfo *argTable, int flags)
          break;
       }
       case ARGV_GENFUNC: {
-         int (*handlerProc)() = (int (*)())(uintptr_t)infoPtr->src;
+         typedef int (*handlerProcType)(void*, const char*, int, char**);
+         handlerProcType handlerProc = (handlerProcType)(uintptr_t)infoPtr->src;
 
          argc = (*handlerProc)(infoPtr->dst, infoPtr->key,
                                argc, argv+srcIndex);


### PR DESCRIPTION
In GCC 15, C23 will be the default C standard.

This PR fixes a warning due to an old-style (K&R/pre-ANSI) function definition, and fixes a compiler error due to C23 interpreting `int foo()` as a function taking no arguments (as it would be in C++) rather than as a function taking unspecified arguments.

This argument-parsing code could still use some attention. For example, standard C has never permitted casting a function pointer to or from any other kind of pointer (although this must work with `void *` on POSIX platforms due to the design of `dlopen()`). This could be avoided by making `src` a union. However, this PR is a good start, and at least allows us to build [`libminc` in Fedora](https://src.fedoraproject.org/rpms/libminc) with GCC 15.