### PR TITLE
Fix false positive in minc2-leak-test on macOS

### DIFF
--- a/testdir/minc2-leak-test.c
+++ b/testdir/minc2-leak-test.c
@@ -23,9 +23,10 @@
 #define CHUNK_LENGTH 10
 
 /**
- * checks for maximum memory usage. units seem to be different between
- * os x and linux despite the documentation, but the code seems to work
- * either way.
+ * checks for maximum memory usage.
+ * ru_maxrss is in kilobytes on Linux but bytes on macOS/BSD.
+ * Normalize to kilobytes so the leak-detection threshold works
+ * on both platforms.
  */
 static int
 check_high_water_mark(void)
@@ -33,7 +34,11 @@ check_high_water_mark(void)
   struct rusage usage;
   if (getrusage(RUSAGE_SELF, &usage) < 0)
     return 0;
-  return usage.ru_maxrss;
+#ifdef __APPLE__
+  return usage.ru_maxrss / 1024;  /* bytes -> KB */
+#else
+  return usage.ru_maxrss;         /* already KB on Linux */
+#endif
 }
 
 static int


### PR DESCRIPTION
ru_maxrss is reported in bytes on macOS but kilobytes on Linux. The leak-detection threshold was implicitly calibrated for KB, causing a spurious "MEMORY LEAK DETECTED" on macOS (especially ARM runners) where values are 1024x larger.

Normalize ru_maxrss to KB on macOS via #ifdef __APPLE__.

References:
- darwin-xnu getrusage.2: "in bytes" https://github.com/apple/darwin-xnu/blob/main/bsd/man/man2/getrusage.2
- Linux getrusage(2): "in KiB" https://man7.org/linux/man-pages/man2/getrusage.2.html