### PR TITLE
Fix uninitialized memory reads found by valgrind

### DIFF
--- a/libsrc/image_conversion.c
+++ b/libsrc/image_conversion.c
@@ -296,6 +296,8 @@ MNCAPI int miicv_create(void)
    /* Values that can be read by user */
    icvp->derv_imgmax = MI_DEFAULT_MAX;
    icvp->derv_imgmin = MI_DEFAULT_MIN;
+   icvp->derv_usr_float = FALSE;
+   icvp->derv_var_float = FALSE;
    for (idim=0; idim<MI_MAX_IMGDIMS; idim++) {
       icvp->derv_dim_step[idim] = 0.0;
       icvp->derv_dim_start[idim] = 0.0;

--- a/testdir/multidim_test.c
+++ b/testdir/multidim_test.c
@@ -5,7 +5,7 @@
 static int
 test1(void)
 {
-  VIO_multidim_array array;
+  VIO_multidim_array array = {0};
   int sizes[TEST1_N_DIMENSIONS] = { 1, 1, 1 };
   int read_sizes[VIO_MAX_DIMENSIONS] = { 5, 5, 5, 5, 5 };
   int i;


### PR DESCRIPTION
## Summary
- Initialize `derv_usr_float` and `derv_var_float` in `miicv_create()` so `miicv_ndattach()` does not read uninitialized heap memory when the `user_do_range` path skips `MI_icv_get_norm()`
- Zero-initialize the stack-allocated `VIO_multidim_array` in `multidim_test` so `multidim_array_is_alloced()` does not branch on an indeterminate `n_dimensions`

## Test plan
- [x] Full test suite (56/56 tests pass)
- [x] All test binaries run clean under `valgrind --leak-check=full --track-origins=yes` with 0 errors and 0 definite/possible leaks
- [x] Includes `minc2-leak-test` (100K iterations, 5.6M allocs, 0 leaks under valgrind)

🤖 Generated with [Claude Code](https://claude.com/claude-code) Opus 4.6 with maximum effort


# Prompt
`Compile and run the tests under valgrind. Enable NIFTI support. Make the minimal changes to address any bugs.`