### PR TITLE
gcc-15 -fanalyzer fixes

### DIFF
--- a/libcommon/minc_error.c
+++ b/libcommon/minc_error.c
@@ -381,7 +381,6 @@ int v_mi2log_message(const char *file, int line, mimsgcode_t code, va_list ap)
     }
     fprintf ( _MI2_log.fp, "%s:%d (from %s): ", file, line, minc_routine_name );
     vfprintf ( _MI2_log.fp, fmt, ap );
-    va_end ( ap );
     fprintf ( _MI2_log.fp, "\n" );
     fflush ( _MI2_log.fp );
   }

--- a/libcommon/minc_error.c
+++ b/libcommon/minc_error.c
@@ -311,6 +311,12 @@ void milog_init(const char *name)
     const char *fname_str = miget_cfg_str(MICFG_LOGFILE);
     int level = miget_cfg_int(MICFG_LOGLEVEL);
 
+    /* Close previously opened log file to avoid leak on re-init */
+    if (_MI_log.fp != NULL && _MI_log.fp != stderr && _MI_log.fp != stdout) {
+	fclose(_MI_log.fp);
+	_MI_log.fp = NULL;
+    }
+
     if (!strlen(fname_str)) {
 	_MI_log.fp = stderr;
     }

--- a/libcommon/time_stamp.c
+++ b/libcommon/time_stamp.c
@@ -114,6 +114,8 @@ char *time_stamp(int argc, char *argv[])
         length += 2;            /* we will need quotes! */
    }
    str = malloc(length);
+   if (str == NULL)
+      return NULL;
 
    /* Copy the time and separator */
    (void) strcpy(str, the_time);

--- a/libsrc/hdf_convenience.c
+++ b/libsrc/hdf_convenience.c
@@ -356,6 +356,7 @@ hdf_get_diminfo(hid_t dst_id, int *ndims, hsize_t dims[])
 
     spc_id = H5Dget_space(dst_id);
     if (spc_id < 0) {
+        *ndims = 0;
         MI_LOG_ERROR(MI_MSG_SNH);
     }
     else {
@@ -2273,9 +2274,11 @@ hdf_open(const char *path, int mode)
                     /* OK, it's compound type. */
                     struct m2_dim *dim = hdf_dim_add(file, MIvector_dimension,
                                                      H5Tget_nmembers(type_id));
-                    dim->is_fake = 1;
-                    dims[ndims++] = H5Tget_nmembers(type_id);
-                    is_compound = 1;
+                    if (dim != NULL) {
+                        dim->is_fake = 1;
+                        dims[ndims++] = H5Tget_nmembers(type_id);
+                        is_compound = 1;
+                    }
                 }
                 H5Tclose(type_id);
             }
@@ -2283,7 +2286,8 @@ hdf_open(const char *path, int mode)
 
             var = hdf_var_add(file, MIimage, "/minc-2.0/image/0/image",
                               ndims, dims);
-            var->is_cmpd = is_compound;
+            if (var != NULL)
+                var->is_cmpd = is_compound;
 
             H5Dclose(dset_id);
         }

--- a/libsrc/image_conversion.c
+++ b/libsrc/image_conversion.c
@@ -1343,7 +1343,7 @@ PRIVATE int MI_icv_access(int operation, mi_icv_type *icvp, long start[],
                                         for allocating variable buffer
                                         (NULL if we don't care) */
    long chunk_count[MAX_VAR_DIMS];   /* Number of elements to get for chunk */
-   long chunk_start[MAX_VAR_DIMS];   /* Starting index for getting a chunk */
+   long chunk_start[MAX_VAR_DIMS] = {0};   /* Starting index for getting a chunk */
    long chunk_size;                  /* Size of chunk in bytes */
    void *chunk_values;               /* Pointer to next chunk to get */
    long var_start[MAX_VAR_DIMS];     /* Coordinates of first var element */

--- a/libsrc/image_conversion.c
+++ b/libsrc/image_conversion.c
@@ -1348,7 +1348,7 @@ PRIVATE int MI_icv_access(int operation, mi_icv_type *icvp, long start[],
    void *chunk_values;               /* Pointer to next chunk to get */
    long var_start[MAX_VAR_DIMS];     /* Coordinates of first var element */
    long var_count[MAX_VAR_DIMS];     /* Edge lengths in variable */
-   long var_end[MAX_VAR_DIMS];       /* Coordinates of last var element */
+   long var_end[MAX_VAR_DIMS] = {0};       /* Coordinates of last var element */
    int firstdim;
    int idim, ndims;
 

--- a/libsrc/minc_basic.h
+++ b/libsrc/minc_basic.h
@@ -119,6 +119,7 @@
          dvalue = (double) *((unsigned char *) ptr); break; \
       case MI_PRIV_SIGNED : \
          dvalue = (double) *((signed char *) ptr); break; \
+      default: dvalue = 0; break; \
       } \
       break; \
    case NC_SHORT : \
@@ -127,6 +128,7 @@
          dvalue = (double) *((unsigned short *) ptr); break; \
       case MI_PRIV_SIGNED : \
          dvalue = (double) *((signed short *) ptr); break; \
+      default: dvalue = 0; break; \
       } \
       break; \
    case NC_INT : \
@@ -135,6 +137,7 @@
          dvalue = (double) *((unsigned int *) ptr); break; \
       case MI_PRIV_SIGNED : \
          dvalue = (double) *((signed int  *) ptr); break; \
+      default: dvalue = 0; break; \
       } \
       break; \
    case NC_FLOAT : \
@@ -148,6 +151,7 @@
          "Attempt to convert NC_NAT value to double"); \
       dvalue = 0; \
       break; \
+   default: dvalue = 0; break; \
    }
 
 #define MI_FROM_DOUBLE(dvalue, type, sign, ptr) \
@@ -165,6 +169,7 @@
          dvalue = MIN(SCHAR_MAX, dvalue); \
          *((signed char *) ptr) = ROUND(dvalue); \
          break; \
+      default: break; \
       } \
       break; \
    case NC_SHORT : \
@@ -179,6 +184,7 @@
          dvalue = MIN(SHRT_MAX, dvalue); \
          *((signed short *) ptr) = ROUND(dvalue); \
          break; \
+      default: break; \
       } \
       break; \
    case NC_INT : \
@@ -193,6 +199,7 @@
          dvalue = MIN(INT_MAX, dvalue); \
          *((signed int *) ptr) = ROUND(dvalue); \
          break; \
+      default: break; \
       } \
       break; \
    case NC_FLOAT : \
@@ -207,6 +214,7 @@
          "Attempt to convert to NC_NAT from double"); \
       dvalue = 0; \
       break; \
+   default: break; \
    }
 
 /**/

--- a/libsrc/netcdf_convenience.c
+++ b/libsrc/netcdf_convenience.c
@@ -378,6 +378,7 @@ MNCAPI char *miexpand_file(const char *path, char *tempfile, int header_only,
    compfile = NULL;
    if ((first_ncerr == NC_SYSERR) && (compress_type == UNKNOWN)) {
       compfile = MALLOC(strlen(path) + max_compression_code_length + 2, char);
+      if (compfile == NULL) MI_RETURN(NULL);
       for (iext=0; iext < complist_length; iext++) {
          (void) strcat(strcpy(compfile, path),
                        compression_code_list[iext].extension);

--- a/libsrc/voxel_loop.c
+++ b/libsrc/voxel_loop.c
@@ -1183,6 +1183,7 @@ PRIVATE void update_history(int mincid, char *arg_string)
 
    /* Allocate a string and get the old history */
    string = MALLOC(att_length, char);
+   if (string == NULL) return;
    string[0] = '\0';
    (void) miattgetstr(mincid, NC_GLOBAL, MIhistory, att_length,
                       string);
@@ -2007,6 +2008,7 @@ PRIVATE Loopfile_Info *initialize_loopfile_info(int num_input_files,
 
    /* Allocate structure */
    loopfile_info = MALLOC(1, Loopfile_Info);
+   if (loopfile_info == NULL) return NULL;
 
    /* Save clobber info */
    if (loop_options->clobber) {
@@ -2029,6 +2031,7 @@ PRIVATE Loopfile_Info *initialize_loopfile_info(int num_input_files,
    /* Save input file names (just copy pointers, not strings) */
    if (num_input_files > 0) {
       loopfile_info->input_files = MALLOC(num_input_files, char *);
+      if (loopfile_info->input_files == NULL) { FREE(loopfile_info); return NULL; }
       for (ifile=0; ifile < num_input_files; ifile++)
          loopfile_info->input_files[ifile] = input_files[ifile];
    }
@@ -2038,6 +2041,7 @@ PRIVATE Loopfile_Info *initialize_loopfile_info(int num_input_files,
    /* Save output file names (just copy pointers, not strings) */
    if (num_output_files > 0) {
       loopfile_info->output_files = MALLOC(num_output_files, char *);
+      if (loopfile_info->output_files == NULL) { FREE(loopfile_info); return NULL; }
       for (ifile=0; ifile < num_output_files; ifile++)
          loopfile_info->output_files[ifile] = output_files[ifile];
    }
@@ -2061,6 +2065,9 @@ PRIVATE Loopfile_Info *initialize_loopfile_info(int num_input_files,
    num_free_files -= num_files;
    loopfile_info->output_mincid = MALLOC(num_files, int);
    loopfile_info->output_icvid = MALLOC(num_files, int);
+   if (loopfile_info->output_mincid == NULL || loopfile_info->output_icvid == NULL) {
+      FREE(loopfile_info); return NULL;
+   }
    for (ifile=0; ifile < num_files; ifile++) {
       loopfile_info->output_mincid[ifile] = MI_ERROR;
       loopfile_info->output_icvid[ifile] = MI_ERROR;
@@ -2084,6 +2091,9 @@ PRIVATE Loopfile_Info *initialize_loopfile_info(int num_input_files,
    num_free_files -= num_files;
    loopfile_info->input_mincid = MALLOC(num_files, int);
    loopfile_info->input_icvid = MALLOC(num_files, int);
+   if (loopfile_info->input_mincid == NULL || loopfile_info->input_icvid == NULL) {
+      FREE(loopfile_info); return NULL;
+   }
    for (ifile=0; ifile < num_files; ifile++) {
       loopfile_info->input_mincid[ifile] = MI_ERROR;
       loopfile_info->input_icvid[ifile] = MI_ERROR;
@@ -2732,6 +2742,7 @@ MNCAPI Loop_Options *create_loop_options(void)
 
    /* Allocate structure */
    loop_options = MALLOC(1, Loop_Options);
+   if (loop_options == NULL) return NULL;
 
    /* Fill in the defaults */
    loop_options->clobber = FALSE;
@@ -3227,6 +3238,7 @@ PRIVATE Loop_Info *create_loop_info(void)
 
    /* Allocate structure */
    loop_info = MALLOC(1, Loop_Info);
+   if (loop_info == NULL) return NULL;
 
    /* Fill in the defaults */
    initialize_loop_info(loop_info);

--- a/libsrc2/datatype.c
+++ b/libsrc2/datatype.c
@@ -94,9 +94,13 @@ int miget_space_name ( mihandle_t volume, char **name )
      */
     length = strlen ( MI_NATIVE );
     *name = malloc ( length + 1 );
+    if ( *name == NULL )
+      return ( MI_ERROR );
     strcpy ( *name, MI_NATIVE );
   } else {
     *name = malloc ( length + 1 );
+    if ( *name == NULL )
+      return ( MI_ERROR );
     result = miget_attr_values ( volume, MI_TYPE_STRING, path_list[i],
                                  "spacetype", length+1, *name );
   }

--- a/libsrc2/dimension.c
+++ b/libsrc2/dimension.c
@@ -97,6 +97,7 @@ int micopy_dimension ( midimhandle_t dim_ptr, midimhandle_t *new_dim_ptr )
     handle->offsets = ( double * ) malloc ( dim_ptr->length * sizeof ( double ) );
 
     if ( handle->offsets == NULL ) {
+      free(handle->name);
       free(handle);
       return ( MI_ERROR );
     }
@@ -133,6 +134,10 @@ int micopy_dimension ( midimhandle_t dim_ptr, midimhandle_t *new_dim_ptr )
     handle->widths = ( double * ) malloc ( dim_ptr->length * sizeof ( double ) );
 
     if ( handle->widths == NULL ) {
+      free(handle->name);
+      free(handle->offsets);
+      free(handle->units);
+      free(handle);
       return ( MI_ERROR );
     }
 
@@ -275,6 +280,8 @@ int micreate_dimension(const char *name, midimclass_t dimclass, midimattr_t attr
     break;
   case MI_DIMCLASS_ANY:
   default:
+    free(handle->comments);
+    free(handle->name);
     free(handle);
     return MI_ERROR;
   }
@@ -284,6 +291,13 @@ int micreate_dimension(const char *name, midimclass_t dimclass, midimattr_t attr
 
   if ( attr & MI_DIMATTR_NOT_REGULARLY_SAMPLED ) {
     handle->widths = ( double * ) malloc ( length * sizeof ( double ) );
+
+    if ( handle->widths == NULL ) {
+      free(handle->comments);
+      free(handle->name);
+      free(handle);
+      return ( MI_ERROR );
+    }
 
     for ( i = 0; i < length; i++ ) {
 
@@ -482,6 +496,8 @@ int miset_apparent_dimension_order ( mihandle_t volume, int array_length,
    */
   if ( volume->dim_indices == NULL ) {
     volume->dim_indices = ( int * ) malloc ( volume->number_of_dims * sizeof ( int ) );
+    if ( volume->dim_indices == NULL )
+      return ( MI_ERROR );
     memset ( volume->dim_indices, -1, sizeof ( volume->number_of_dims ) );
   }
 
@@ -576,6 +592,8 @@ int miset_apparent_dimension_order_by_name ( mihandle_t volume, int array_length
    */
   if ( volume->dim_indices == NULL ) {
     volume->dim_indices = ( int * ) malloc ( volume->number_of_dims * sizeof ( int ) );
+    if ( volume->dim_indices == NULL )
+      return ( MI_ERROR );
     memset ( volume->dim_indices, -1, sizeof ( volume->number_of_dims ) );
   }
 

--- a/libsrc2/grpattr.c
+++ b/libsrc2/grpattr.c
@@ -95,6 +95,10 @@ int milist_start ( mihandle_t vol, const char *path, int flags,
   }
 
   frame = ( struct milistframe * ) malloc ( sizeof ( struct milistframe ) );
+  if ( frame == NULL ) {
+    free ( data );
+    return ( MI_ERROR );
+  }
   frame->next = NULL;
   frame->grp_id = grp_id;
   frame->att_idx = 0;
@@ -905,6 +909,8 @@ int miset_attr_values ( mihandle_t vol, mitype_t data_type, const char *path,
   if ( pch != NULL ) {
     slength = strlen ( path ) - ( pch - path );
     std_name = malloc ( slength + 1 );
+    if ( std_name == NULL )
+      return ( MI_ERROR );
 
     for ( i = 0; i < slength; i++ )
       std_name[i] = path[pch - path + 1 + i];
@@ -912,6 +918,8 @@ int miset_attr_values ( mihandle_t vol, mitype_t data_type, const char *path,
     std_name[slength] = '\0';
   } else {
     std_name = malloc ( strlen ( path ) + 1 );
+    if ( std_name == NULL )
+      return ( MI_ERROR );
     strcpy ( std_name, path );
   }
 

--- a/libsrc2/m2util.c
+++ b/libsrc2/m2util.c
@@ -1930,6 +1930,8 @@ alloc2d ( int n, int m )
     mat[i] = ( double * ) malloc ( m * sizeof ( double ) );
 
     if ( mat[i] == NULL ) {
+      while ( --i >= 0 )
+        free ( mat[i] );
       free(mat);
       return NULL;
     }

--- a/libsrc2/m2util.c
+++ b/libsrc2/m2util.c
@@ -2080,6 +2080,8 @@ scaled_maximal_pivoting_gaussian_elimination ( int   n,
   int success;
 
   s = alloc1d ( n );
+  if ( s == NULL )
+    return ( FALSE );
 
   for ( i = 0; i < n; i++ )
     row[i] = i;
@@ -2182,6 +2184,13 @@ scaled_maximal_pivoting_gaussian_elimination_real ( int n,
   a = alloc2d ( n, n );
   solution = alloc2d ( n, n_values );
 
+  if ( row == NULL || a == NULL || solution == NULL ) {
+    free ( row );
+    if ( a != NULL ) free2d ( n, a );
+    if ( solution != NULL ) free2d ( n, solution );
+    return ( FALSE );
+  }
+
   for ( i = 0; i < n; i++ ) {
     for ( j = 0; j < n; j++ )
       a[i][j] = coefs[i][j];
@@ -2222,6 +2231,12 @@ invert_4x4_matrix ( double matrix[4][4], /**< Input matrix */
 
   mtmp = alloc2d ( 4, 4 );
   itmp = alloc2d ( 4, 4 );
+
+  if ( mtmp == NULL || itmp == NULL ) {
+    if ( mtmp != NULL ) free2d ( 4, mtmp );
+    if ( itmp != NULL ) free2d ( 4, itmp );
+    return ( MI_ERROR );
+  }
 
   /* Start off with the identity matrix. */
   for ( i = 0; i < 4; i++ ) {

--- a/libsrc2/volume.c
+++ b/libsrc2/volume.c
@@ -1219,6 +1219,8 @@ static int _miget_file_dimension(mihandle_t volume, const char *dimname,
   snprintf(path, sizeof(path), MI_ROOT_PATH "/dimensions/%s", dimname);
   /* Allocate space for the dimension handle */
   hdim = (midimhandle_t) malloc(sizeof (*hdim));
+  if (hdim == NULL)
+    return (MI_ERROR);
   /* Initialize everything to zero */
   memset(hdim, 0, sizeof (*hdim));
 

--- a/volume_io/Prog_utils/files.c
+++ b/volume_io/Prog_utils/files.c
@@ -1234,6 +1234,8 @@ VIOAPI  VIO_STR  extract_directory(
     VIO_STR  expanded, directory;
 
     expanded = expand_filename( filename );
+    if( expanded == NULL )
+        return( create_string( "." ) );
 
     slash_index = string_length(expanded) - 1;
 
@@ -1285,6 +1287,8 @@ VIOAPI  VIO_STR  get_absolute_filename(
        absolute (begins with '/'), then prefix the directory to the filename */
 
     expanded = expand_filename( filename );
+    if( expanded == NULL )
+        return( create_string( NULL ) );
 
     if( string_length( directory ) > 0 && expanded[0] != '/' )
     {
@@ -1642,7 +1646,7 @@ VIOAPI  VIO_Status  input_possibly_quoted_string(
     FILE            *file,
     VIO_STR          *str )
 {
-    VIO_BOOL  quoted;
+    VIO_BOOL  quoted = FALSE;
     char     ch, quote;
     VIO_Status   status;
 
@@ -1673,7 +1677,7 @@ VIOAPI  VIO_Status  input_possibly_quoted_string(
         status = input_character( file, &ch );
     }
 
-    if( !quoted )
+    if( !quoted && status == VIO_OK )
         (void) unget_character( file, ch );
 
     if( status != VIO_OK )

--- a/volume_io/Volumes/input_mnc2.c
+++ b/volume_io/Volumes/input_mnc2.c
@@ -179,6 +179,7 @@ static  Minc_file  initialize_minc_input_from_minc2_id(
         slices_count*=dimension_size[d];
       }
       slice_start=(misize_t *)calloc(n_slice_dimensions,sizeof(misize_t));
+      if(slice_start==NULL) return VIO_ERROR;
       miget_slice_range(file->minc2id,slice_start,n_slice_dimensions,&volume_max,&volume_min);
 
       do

--- a/volume_io/Volumes/input_mnc2.c
+++ b/volume_io/Volumes/input_mnc2.c
@@ -179,7 +179,7 @@ static  Minc_file  initialize_minc_input_from_minc2_id(
         slices_count*=dimension_size[d];
       }
       slice_start=(misize_t *)calloc(n_slice_dimensions,sizeof(misize_t));
-      if(slice_start==NULL) return VIO_ERROR;
+      if(slice_start==NULL) return NULL;
       miget_slice_range(file->minc2id,slice_start,n_slice_dimensions,&volume_max,&volume_min);
 
       do

--- a/volume_io/Volumes/input_nifti.c
+++ b/volume_io/Volumes/input_nifti.c
@@ -615,6 +615,7 @@ input_more_nifti_format_file(
 
     VIO_Real *temp_buffer = malloc(in_ptr->sizes_in_file[0] *
                                    sizeof(VIO_Real));
+    if (temp_buffer == NULL) return VIO_ERROR;
 
     /* If the memory for the volume has not been allocated yet,
      * initialize that memory now.
@@ -625,6 +626,7 @@ input_more_nifti_format_file(
       if (!volume_is_alloced(volume))
       {
         print_error("Failed to allocate volume.\n");
+        free(temp_buffer);
         return FALSE;
       }
     }

--- a/volume_io/Volumes/volume_cache.c
+++ b/volume_io/Volumes/volume_cache.c
@@ -459,7 +459,7 @@ static  void  write_cache_block(
     int              file_start[VIO_MAX_DIMENSIONS];
     int              file_count[VIO_MAX_DIMENSIONS];
     int              volume_sizes[VIO_MAX_DIMENSIONS];
-    int              block_start[VIO_MAX_DIMENSIONS];
+    int              block_start[VIO_MAX_DIMENSIONS] = {0};
     void             *array_data_ptr;
 
     minc_file = (Minc_file) cache->minc_file;
@@ -1239,8 +1239,8 @@ static  VIO_cache_block_struct  *get_cache_block_for_voxel(
 {
     VIO_cache_block_struct   *block;
     VIO_cache_lookup_struct  *lookup0, *lookup1, *lookup2, *lookup3, *lookup4;
-    int                  block_index;
-    int                  block_start[VIO_MAX_DIMENSIONS];
+    int                  block_index = 0;
+    int                  block_start[VIO_MAX_DIMENSIONS] = {0};
     int                  n_dims, hash_index;
     VIO_volume_cache_struct  *cache;
 


### PR DESCRIPTION
## Summary

Compiled libminc with gcc-15 `-fanalyzer` and fixed all genuine bugs it found across 16 files (100 insertions, 12 deletions). All fixes are minimal, internal-only changes — no external interface modifications.

### Bug categories fixed:

- **NULL dereferences after allocation failures** (12 fixes): Added missing NULL checks after malloc/calloc/MALLOC in `m2util.c`, `grpattr.c`, `dimension.c`, `datatype.c`, `volume.c`, `voxel_loop.c`, `netcdf_convenience.c`, `hdf_convenience.c`, `time_stamp.c`, `input_mnc2.c`, `input_nifti.c`, `files.c`
- **Memory leaks on error paths** (4 fixes): Fixed partial allocation cleanup in `alloc2d()`, dimension handle leaks in `micopy_dimension()`/`micreate_dimension()`, temp buffer leak in `input_nifti.c`
- **Uninitialized variables** (4 fixes): Zero-initialized `chunk_start`, `var_end` in `image_conversion.c`; `block_start`/`block_index` in `volume_cache.c`; `quoted` in `files.c`; guarded use of uninitialized `ch` in `files.c`
- **Resource leak**: FILE handle leak in `milog_init()` on re-initialization
- **va_list misuse**: Double `va_end` in `v_mi2log_message()`
- **Missing switch defaults**: Added default cases to `MI_TO_DOUBLE`/`MI_FROM_DOUBLE` macros

### Remaining warnings

19 warnings remain, all false positives (e.g., callers always pass valid pointers, loops always fill arrays, static-lifetime resources).

## Test plan

- [x] All 56 tests pass after every individual commit
- [x] Full clean rebuild with `-fanalyzer` confirms no remaining actionable warnings
- [x] `ctest --parallel 32 --output-on-failure` passes on final state

🤖 Generated with [Claude Code](https://claude.com/claude-code)