### PR TITLE
LIBMINCConfig: use recorded HDF5 directly (fix macOS CMake 4.x find)

### DIFF
--- a/LIBMINCConfig.cmake.in
+++ b/LIBMINCConfig.cmake.in
@@ -33,25 +33,35 @@ set(LIBMINC_NIFTI_SUPPORT @LIBMINC_NIFTI_SUPPORT@)
 # ----- Resolve transitive dependencies -----
 find_dependency(ZLIB REQUIRED)
 
-set(HDF5_NO_FIND_PACKAGE_CONFIG_FILE ON)
-# Provide hints so the system FindHDF5 can find the same HDF5 we were built with
-# (especially important on Debian/Ubuntu where the serial variant lives in
-#  non-standard paths like /usr/include/hdf5/serial)
+# Resolve HDF5. libminc records the exact HDF5 it was built against; when that
+# library still exists, use it directly instead of re-running find_package(HDF5).
+# Re-discovery via the module FindHDF5 is unreliable across CMake/platform
+# combinations -- notably macOS CMake 4.x, where the h5cc-wrapper probe fails
+# ("Unable to determine HDF5 C flags from HDF5 wrapper") and the HDF5_ROOT
+# fallback is ignored (CMP0074), giving "missing HDF5_LIBRARIES". Setting the
+# result variables ourselves is robust and matches exactly what we linked.
 set(_LIBMINC_SAVED_HDF5_INCLUDE_DIR "@HDF5_INCLUDE_DIR@")
 set(_LIBMINC_SAVED_HDF5_LIBRARY     "@HDF5_LIBRARY@")
-if(_LIBMINC_SAVED_HDF5_INCLUDE_DIR)
-  if(NOT HDF5_C_INCLUDE_DIR)
-    set(HDF5_C_INCLUDE_DIR "${_LIBMINC_SAVED_HDF5_INCLUDE_DIR}" CACHE PATH "HDF5 C include dir (from libminc)")
+if(_LIBMINC_SAVED_HDF5_LIBRARY AND EXISTS "${_LIBMINC_SAVED_HDF5_LIBRARY}")
+  if(NOT HDF5_FOUND)
+    set(HDF5_INCLUDE_DIRS  "${_LIBMINC_SAVED_HDF5_INCLUDE_DIR}")
+    set(HDF5_C_INCLUDE_DIR "${_LIBMINC_SAVED_HDF5_INCLUDE_DIR}")
+    set(HDF5_LIBRARIES     "${_LIBMINC_SAVED_HDF5_LIBRARY}")
+    set(HDF5_C_LIBRARIES   "${_LIBMINC_SAVED_HDF5_LIBRARY}")
+    set(HDF5_FOUND TRUE)
   endif()
-endif()
-if(_LIBMINC_SAVED_HDF5_LIBRARY)
-  if(NOT HDF5_hdf5_LIBRARY_RELEASE)
-    set(HDF5_hdf5_LIBRARY_RELEASE "${_LIBMINC_SAVED_HDF5_LIBRARY}" CACHE FILEPATH "HDF5 C library (from libminc)")
+else()
+  # No usable saved path (e.g. HDF5 was a system package); fall back to a fresh
+  # lookup. Allow CONFIG packages too -- don't force module mode.
+  set(_LIBMINC_SAVED_HDF5_INCLUDE_DIR_HINT "${_LIBMINC_SAVED_HDF5_INCLUDE_DIR}")
+  if(_LIBMINC_SAVED_HDF5_INCLUDE_DIR_HINT AND NOT HDF5_C_INCLUDE_DIR)
+    set(HDF5_C_INCLUDE_DIR "${_LIBMINC_SAVED_HDF5_INCLUDE_DIR_HINT}" CACHE PATH "HDF5 C include dir (from libminc)")
   endif()
+  unset(_LIBMINC_SAVED_HDF5_INCLUDE_DIR_HINT)
+  find_dependency(HDF5 REQUIRED COMPONENTS C)
 endif()
 unset(_LIBMINC_SAVED_HDF5_INCLUDE_DIR)
 unset(_LIBMINC_SAVED_HDF5_LIBRARY)
-find_dependency(HDF5 REQUIRED COMPONENTS C)
 
 if(HAVE_MINC1)
   # NetCDF is required when MINC1 support was enabled


### PR DESCRIPTION
`LIBMINCConfig.cmake` resolves HDF5 via `find_dependency(HDF5)` with module mode forced (`HDF5_NO_FIND_PACKAGE_CONFIG_FILE ON`). On macOS with CMake 4.x this fails:

- the `h5cc` compiler-wrapper probe can't determine flags (`Unable to determine HDF5 C flags from HDF5 wrapper`), and
- the `HDF5_ROOT` fallback is ignored (CMP0074 is OLD in the config's pushed policy scope),

so any downstream `find_package(LIBMINC)` errors with `Could NOT find HDF5 (missing: HDF5_LIBRARIES)` — which breaks ITK's MINC ThirdParty module configure in a superbuild.

libminc already records the exact HDF5 include dir / library it was built against. When that library still exists, set `HDF5_FOUND` / `HDF5_LIBRARIES` / `HDF5_C_LIBRARIES` / `HDF5_INCLUDE_DIRS` from it directly and skip the fragile re-discovery. Only fall back to `find_dependency(HDF5)` (no longer forcing module mode, so CONFIG packages work too) when there's no usable saved path, e.g. a system HDF5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)