### PR TITLE
Forward-port macOS leak-test (#144) and valgrind (#145) fixes to develop-1.9.18

### DIFF
--- a/libsrc/image_conversion.c
+++ b/libsrc/image_conversion.c
@@ -302,6 +302,8 @@ MNCAPI int miicv_create(void)
    /* Values that can be read by user */
    icvp->derv_imgmax = MI_DEFAULT_MAX;
    icvp->derv_imgmin = MI_DEFAULT_MIN;
+   icvp->derv_usr_float = FALSE;
+   icvp->derv_var_float = FALSE;
    for (idim=0; idim<MI_MAX_IMGDIMS; idim++) {
       icvp->derv_dim_step[idim] = 0.0;
       icvp->derv_dim_start[idim] = 0.0;

--- a/testdir/minc2-leak-test.c
+++ b/testdir/minc2-leak-test.c
@@ -23,9 +23,10 @@
 #define CHUNK_LENGTH 10
 
 /**
- * checks for maximum memory usage. units seem to be different between
- * os x and linux despite the documentation, but the code seems to work
- * either way.
+ * checks for maximum memory usage.
+ * ru_maxrss is in kilobytes on Linux but bytes on macOS/BSD.
+ * Normalize to kilobytes so the leak-detection threshold works
+ * on both platforms.
  */
 static int
 check_high_water_mark(void)
@@ -33,7 +34,11 @@ check_high_water_mark(void)
   struct rusage usage;
   if (getrusage(RUSAGE_SELF, &usage) < 0)
     return 0;
-  return usage.ru_maxrss;
+#ifdef __APPLE__
+  return usage.ru_maxrss / 1024;  /* bytes -> KB */
+#else
+  return usage.ru_maxrss;         /* already KB on Linux */
+#endif
 }
 
 static int

--- a/testdir/multidim_test.c
+++ b/testdir/multidim_test.c
@@ -6,7 +6,7 @@
 static int
 test1(void)
 {
-  VIO_multidim_array array;
+  VIO_multidim_array array = {0};
   int sizes[TEST1_N_DIMENSIONS] = { 1, 1, 1 };
   int read_sizes[VIO_MAX_DIMENSIONS] = { 5, 5, 5, 5, 5 };
   int i;


### PR DESCRIPTION
Forward-port the macOS `minc2-leak-test` fix (#144) and the valgrind uninitialized-read fix (#145) from `develop` to `develop-1.9.18`.

Both were merged to `develop` but never landed on `develop-1.9.18`. minc-toolkit-v2 (develop-1.9.18) pins libminc at this branch's tip, and its macOS release CI fails on `minc2-leak-test`:

> `ru_maxrss` is kilobytes on Linux but **bytes on macOS/BSD**, so the leak-detection high-water-mark threshold sees a false positive. Observed failing on the macos-15 / macos-26 runners (passes on macos-14). #144 normalizes to KB under `__APPLE__`.

Both commits cherry-pick cleanly onto `develop-1.9.18` (no conflicts):

- Fix false positive in minc2-leak-test on macOS — `testdir/minc2-leak-test.c` (#144)
- Fix uninitialized memory reads found by valgrind — `libsrc/image_conversion.c`, `testdir/multidim_test.c` (#145)

Original authorship preserved. This lets the toolkit keep its `pin == develop-1.9.18 tip` invariant while picking up the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ms6tcxph93KbxCpWyQxAr
