### PR TITLE
Resolve libminc's install RPATH relative to the loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,10 +606,21 @@ set_target_properties(${LIBMINC_LIBRARY}
   POSITION_INDEPENDENT_CODE ON
 )
 
-# Scope INSTALL_RPATH to the target instead of global CMAKE_INSTALL_RPATH
+# Scope INSTALL_RPATH to the target instead of global CMAKE_INSTALL_RPATH.
+#
+# Resolve it relative to the loaded object rather than baking in
+# CMAKE_INSTALL_PREFIX: libminc and the libraries it links against install to
+# the same directory, so $ORIGIN is that directory, and an install that is
+# later moved still resolves. The absolute form silently kept pointing at the
+# configure-time prefix, which is a dangling path once the tree is relocated.
+if(APPLE)
+  set(LIBMINC_INSTALL_RPATH "@loader_path")
+else()
+  set(LIBMINC_INSTALL_RPATH "$ORIGIN")
+endif()
 set_target_properties(${LIBMINC_LIBRARY}
  PROPERTIES
-  INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+  INSTALL_RPATH "${LIBMINC_INSTALL_RPATH}"
 )
 
 if(LIBMINC_MINC1_SUPPORT)


### PR DESCRIPTION
## Why

The target-scoped `INSTALL_RPATH` bakes in `CMAKE_INSTALL_PREFIX`:

```cmake
set_target_properties(${LIBMINC_LIBRARY}
 PROPERTIES
  INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
)
```

Move the install and that path dangles — `libminc2.so` then has to be found some other way, via `LD_LIBRARY_PATH` or the RPATH of whatever loaded it.

## What

`$ORIGIN` (`@loader_path` on Apple). libminc and the libraries it links install to the same directory, so `$ORIGIN` names it without naming the prefix, and survives a move. The target scoping is kept — only the value changes.

## How it was found

Verifying the superbuild's equivalent change, BIC-MNI/minc-toolkit-v2#232. After a full build and install there — ITK from source, 12 of 13 dependencies from the system — `libminc2.so.5.3.0` was the **single** object out of 419 binaries and shared libraries still carrying an absolute run path:

```
relative: 418   ABSOLUTE: 1   none: 138 (all scripts)
  libminc2.so.5.3.0 -> /.../mt-reloc-prefixA/lib
```

because this target property overrides the superbuild's `CMAKE_INSTALL_RPATH`.

It is easy to miss: with system HDF5, NetCDF and zlib, `libminc2` has no dependency inside the prefix at all, so the dangling path costs nothing and everything still runs after a move. With those bundled it would matter.

## Verification

Standalone shared build, installed:

```
$ readelf -d lib/libminc2.so.5.3.0 | grep RUNPATH
  RUNPATH  [$ORIGIN]
```

## Relationship to #232

Independent — this is correct on its own, and standalone libminc benefits either way. But BIC-MNI/minc-toolkit-v2#232 is not complete without it: that PR makes every other component loader-relative, and this target property is the one place it cannot reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019katBUnczdvUS7WQ4RpVoa